### PR TITLE
rlcompleter.py: completion with case insensitive

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -11,6 +11,10 @@ Tip: to use the tab key as the completion key, call
 
     readline.parse_and_bind("tab: complete")
 
+And to make completion with case insensitive, call
+
+    rlcompleter.set_case_insensitive(True)
+
 Notes:
 
 - Exceptions raised by the completer function are *ignored* (and generally cause
@@ -166,7 +170,7 @@ class Completer:
             noprefix = None
         while True:
             for word in words:
-                if (word[:n] == attr and
+                if (re.match(attr, word[:n], flags=_re_ignorecase_flags) and
                     not (noprefix and word[:n+1] == noprefix)):
                     match = "%s.%s" % (expr, word)
                     try:
@@ -184,6 +188,12 @@ class Completer:
                 noprefix = None
         matches.sort()
         return matches
+
+_re_ignorecase_flags = 0
+def set_case_insensitive(option):
+    import re
+    global _re_ignorecase_flags
+    _re_ignorecase_flags = option and re.IGNORECASE or 0
 
 def get_class_members(klass):
     ret = dir(klass)


### PR DESCRIPTION
Added an option to the user to make completions with case insensitive / sensitive.
rlcompleter.set_case_insensitive(True) # to enable case insensitive 

Added documentation accordingly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
